### PR TITLE
Redirect stdin to the stubbed command to allow users to verify stub inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ Here, we used the `assert_success` and `assert_output` functions from [bats-asse
 
 Once the test case is done, you should call `unstub <program>` in order to clean up the temporary files, and make a final check that all the plans have been met for the stub.
 
+### Verifying stub input
+
+If you want to verify that your stub was passed the correct data in STDIN, you can redirect its content to a temporary file and check it.
+
+```
+@test "send_message" {
+
+	stub curl \
+		"${_CURL_ARGS} : cat > ${_TMP_DIR}/actual-input ; cat ${_RESOURCES_DIR}/mock-output"
+	
+	run send_message
+	assert_success
+	diff "${_TMP_DIR}/actual-input" "${_RESOURCES_DIR}/expected-input"
+}
+```
+
 
 ## Troubleshooting
 

--- a/binstub
+++ b/binstub
@@ -85,7 +85,7 @@ while IFS= read -r line; do
     # in a subshell. Otherwise, log the failure.
     if [ $result -eq 0 ] ; then
       debug "running $command"
-	  debug "command input is $input"
+      debug "command input is $input"
       set +e
       ( eval "$command"  <<< "$input" )
       status="$?"

--- a/binstub
+++ b/binstub
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+# If stdin comes from a pipe, save its content for later
+if ! [ -t 0 ]; then
+	input="$(cat)"
+fi
+
 status=0
 program="${0##*/}"
 PROGRAM="$(echo "$program" | tr a-z- A-Z_)"
@@ -80,8 +85,9 @@ while IFS= read -r line; do
     # in a subshell. Otherwise, log the failure.
     if [ $result -eq 0 ] ; then
       debug "running $command"
+	  debug "command input is $input"
       set +e
-      ( eval "$command" )
+      ( eval "$command"  <<< "$input" )
       status="$?"
       debug "command result was $status"
       set -e


### PR DESCRIPTION
This PR adds a feature that I needed for my tests.

Basically, we save the content of stdin early in the `binstub` process to be able to redirect it to the stub command. This way, we can verify what input was given to our stub.

STDIN is only read if it is not a tty, or test will wait forever for some user input.