### PR TITLE
Add --exists to unstub

### DIFF
--- a/stub.bash
+++ b/stub.bash
@@ -21,6 +21,11 @@ stub() {
 }
 
 unstub() {
+  local assert_existing=0
+  if [ "$1" == "--exists" ]; then
+    assert_existing=1
+    shift
+  fi
   local program="$1"
   local prefix="$(echo "$program" | tr a-z- A-Z_)"
   local path="${BATS_MOCK_BINDIR}/${program}"
@@ -28,7 +33,12 @@ unstub() {
   export "${prefix}_STUB_END"=1
 
   local STATUS=0
-  "$path" || STATUS="$?"
+  if [ -f "$path" ]; then
+    "$path" || STATUS="$?"
+  elif [ $assert_existing -eq 1 ]; then
+    echo "$program is not stubbed" >&2
+    STATUS=1
+  fi
 
   rm -f "$path"
   rm -f "${BATS_MOCK_TMPDIR}/${program}-stub-plan" "${BATS_MOCK_TMPDIR}/${program}-stub-run"

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -49,3 +49,32 @@ load '../stub'
 
   unstub mycommand
 }
+
+@test "Error with unstub --exists" {
+  # Case 1: Double unstub
+  stub mycommand "foo : echo 'Bar'"
+  run mycommand foo
+  [ "$status" -eq 0 ]
+  run unstub mycommand
+  [ "$status" -eq 0 ]
+  [ "$output" == "" ]
+  run unstub mycommand
+  [ "$status" -eq 0 ]
+  [ "$output" == "" ]
+  # With --exists
+  stub mycommand "foo : echo 'Bar'"
+  run mycommand foo
+  [ "$status" -eq 0 ]
+  run unstub --exists mycommand
+  [ "$status" -eq 0 ]
+  [ "$output" == "" ]
+  run unstub --exists mycommand
+  [ "$status" -eq 1 ]
+  [ "$output" == "mycommand is not stubbed" ]
+  # Case 2: Unstub non-stubbed command
+  run unstub --exists non_stubbed_command
+  [ "$status" -eq 1 ]
+  run unstub non_stubbed_command2
+  [ "$status" -eq 0 ]
+  [ "$output" == "" ]
+}


### PR DESCRIPTION
Additionally assert that the given command was stubbed
Also avoids error message when parameter was not given and program was not stubbed

@lox I'm totally unsure how to implement this. Reasoning was that if you put `unstub foo` in `teardown` you get an error on stderr if you already unstubbed foo  in the test. But you usually want it there to cleanup stuff and/or do a final verification.

My first attempt was `--allow-missing` which is the current behavior minus the message: `status=0, output=""` and without that param it would fail with `status=1` and a message. However this changes existing behavior because the current version does not fail if the command does not exist (anymore)

Probably better solution:
- `unstub` fails if command does not exist
- `unstub --allow-missing` avoids this
- `unstub_all` removes all stubs without issuing messages and errors
- `unstub_verify` removes and verifies all set stubs

This is a breaking change, but allows for clean tests: `unstub` for use IN tests if one wants to do that, the parameter for compatibility and the other 2 for cleanup (if unstub is used in the tests) or verification (if it isn't)