### PR TITLE
Correct huge bug with exit status of mocked commands

### DIFF
--- a/binstub
+++ b/binstub
@@ -142,5 +142,5 @@ else
   } > "${!_STUB_RUN}"
 
   debug "result ${!_STUB_RESULT}"
-  exit "${!_STUB_RESULT}"
+  exit "$status"
 fi


### PR DESCRIPTION
A bug slipped through in our latest release that broke testing of commands that you expect to fail in a particular way