### PR TITLE
Improved docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ If you want to verify that your stub was passed the correct data in STDIN, you c
 
 ```bash
 @test "send_message" {
+  stub curl \
+    "${_CURL_ARGS} : cat > ${_TMP_DIR}/actual-input ; cat ${_RESOURCES_DIR}/mock-output"
 
-	stub curl \
-		"${_CURL_ARGS} : cat > ${_TMP_DIR}/actual-input ; cat ${_RESOURCES_DIR}/mock-output"
-
-	run send_message
-	assert_success
-	diff "${_TMP_DIR}/actual-input" "${_RESOURCES_DIR}/expected-input"
+  run send_message
+  assert_success
+  diff "${_TMP_DIR}/actual-input" "${_RESOURCES_DIR}/expected-input"
+  unstub curl
 }
 ```
 
@@ -99,15 +99,17 @@ If you want to verify that your stub was called with the correct arguments, you 
 
 ```bash
 @test "send_message" {
+  stub curl \
+    "-X \* \* : echo \$3 > ${_TMP_DIR}/curl-url; echo \$2 > ${_TMP_DIR}/curl-method"
 
-	stub curl \
-		"-X \* \* : echo \$3 > ${_TMP_DIR}/curl-url; echo \$2 > ${_TMP_DIR}/curl-method"
-
-	run send_message
-	assert_success
-	diff "${_TMP_DIR}/curl-url" "${_RESOURCES_DIR}/expected-url"
+  run send_message
+  
+  assert_success
+  diff "${_TMP_DIR}/curl-url" "${_RESOURCES_DIR}/expected-url"
   called_method="$(cat ${_TMP_DIR}/curl-method)"
   [ "$called_method" == "POST" ]
+
+  unstub curl
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Recommended installation is via git submodule. Assuming your project's bats
 tests are in `test`:
 
 ``` sh
-git submodule add https://github.com/lox/bats-mock test/helpers/mocks
+git submodule add https://github.com/buildkite-plugins/bats-mock test/helpers/mocks
 git commit -am 'added bats-mock module'
 ```
 
@@ -51,10 +51,9 @@ format_date() {
 }
 
 setup() {
-  _DATE_ARGS='-r 222'
   stub date \
-      "${_DATE_ARGS} : echo 'I am stubbed!'" \
-      "${_DATE_ARGS} : echo 'Wed Dec 31 18:03:42 CST 1969'"
+      "-r 222 : echo 'I am stubbed!'" \
+      "-r \* : echo 'Wed Dec 31 18:03:42 CST 1969'"
 }
 
 teardown() {
@@ -70,7 +69,7 @@ teardown() {
 }
 ```
 
-This verifies that `format_date` indeed called `date` using the args defined in `${_DATE_ARGS}` (which can not be declared in the test-case with local), and made proper use of the output of it.
+This verifies that `format_date` indeed called `date` using the args defined in each specified stub, and made proper use of the output of it. Note that `\* will match any **one** argument.
 
 The plan is verified, one by one, as the calls come in, but the final check that there are no remaining un-met plans at the end is left until the stub is removed with `unstub`.
 
@@ -94,12 +93,32 @@ If you want to verify that your stub was passed the correct data in STDIN, you c
 }
 ```
 
+### Verifying stub arguments
+
+If you want to verify that your stub was called with the correct arguments, you can use (escaped) positional variables in the command. They will be interpreted correctly (`$1`, `$2`, ...).
+
+```bash
+@test "send_message" {
+
+	stub curl \
+		"-X \* \* : echo \$3 > ${_TMP_DIR}/curl-url; echo \$2 > ${_TMP_DIR}/curl-method"
+
+	run send_message
+	assert_success
+	diff "${_TMP_DIR}/curl-url" "${_RESOURCES_DIR}/expected-url"
+  called_method="$(cat ${_TMP_DIR}/curl-method)"
+  [ "$called_method" == "POST" ]
+}
+```
+
 ## Troubleshooting
 
-It can be difficult to figure out why your mock has failed. You can enable debugging by setting an environment variable (in this case for `date`):
+It can be difficult to figure out why your mock has failed. You can enable debugging setting an environment variable called after the command being stubbed (all in underscore-separeted, uppercase) with the `STUB_DEBUG` suffix. The value of the variable needs to be a device or file descriptor where to redirect the debugging output. Recommended value is `3`, which should make the output compatible with tap's expectation but you can also use `/dev/tty`.
+
+If you have stubbed the `date` command, you can do something like:
 
 ```
-export DATE_STUB_DEBUG=/dev/tty
+export DATE_STUB_DEBUG=3
 ```
 
 ## How it works


### PR DESCRIPTION
Just corrected a few bits here and there in the documentation.

Most importantly, I added clarifications about the usage of `\*` in stubs and an example of how it can be used for argument checking.

Thanks to @JAORMX for letting us know that was not clear enough in https://github.com/buildkite-plugins/buildkite-plugin-tester/issues/51