### PR TITLE
Flamefire improvements + bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,41 @@ If you want to verify that your stub was passed the correct data in STDIN, you c
 }
 ```
 
+### Accepting any arguments
+
+Sometimes the argument is to complicated to determine in advance so you just want to ensure that an argument is given.
+Or you want to assert that the argument matches a given pattern, e.g. starts with a prefix.   
+When even that is undesired then you can even accept any call with any number of arguments.
+
+```bash
+@test "send_message" {
+
+	stub grep \
+    '* /home* : printf "%s" "$1" > ${_RESOURCES_DIR}/mock-output' \
+    'exit 0'
+  
+  # Matches first and hence prints the patter to mock-output
+  grep "$complicated_pattern" /home/user/file
+
+  # Matches second and simply returns success
+  grep -E -i "$some_pattern" "$some_file"
+
+  # If your command contains ' : ' just start with double-colon
+  stub cat '::echo "Hello : World"'
+  # Prints "Hello : World"
+  cat foo bar
+
+  # Note that a single colon at the start is interpreted as "no arguments"
+  stub cat ': echo "OK"'
+  ! cat foo # `cat` stub fails as an argument was passed
+
+  # But don't forget the space!
+  stub cat':echo "OK"'
+  # Will accept any arguments and execute `:echo "OK"` -> Fails
+  !cat foo # command `:echo` not found
+}
+```
+
 ### Incremental Stubbing
 
 In some case it might be preferable to define the invocation plan incrementally to mirror the actual behavior of the program under test.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,30 @@ If you want to verify that your stub was passed the correct data in STDIN, you c
 }
 ```
 
+### Incremental Stubbing
+
+In some case it might be preferable to define the invocation plan incrementally to mirror the actual behavior of the program under test.
+This can be done by invocing `stub` multiple times with the same command.   
+In case you want to to start with a new plan call `unstub` first.
+
+```bash
+# Function to test
+function install() {
+  apt-get update
+  pt-add-repository -y myrepo
+  apt-get update
+}
+
+@test "test installation" {
+  stub apt-get "update : "
+  stub apt-add-repository "-y myrepo : "
+  stub apt-get "update : " # Appends to existing plan
+  run install
+  unstub apt-get # Verifies plan and removes all remaining files
+  stub apt-get "upgrade" # Start with a new plan
+}
+```
+
 ## Troubleshooting
 
 It can be difficult to figure out why your mock has failed. You can enable debugging by setting an environment variable (in this case for `date`):

--- a/binstub
+++ b/binstub
@@ -61,7 +61,10 @@ while IFS= read -r line; do
     # strings. This is less than ideal, but the pattern input
     # is also already eval'd elsewhere. At least this handles
     # things like newlines (which xargs doesn't)
+    origFlags="$-"
+    set -f
     eval "parsed_patterns=(${patterns})"
+    set "-$origFlags"
 
     debug "patterns  [${#parsed_patterns[@]}] = $(printf "'%q' " "${parsed_patterns[@]}")"
     debug "arguments [${#arguments[@]}] = $(printf "'%q' " "${arguments[@]}")"

--- a/binstub
+++ b/binstub
@@ -109,7 +109,6 @@ done < "${!_STUB_PLAN}"
 
 
 if [ -n "${!_STUB_END}" ]; then
-  echo "${_STUB_DEBUG}"
   debug "unstubbing"
 
   if [ ! -f "${!_STUB_RUN}" ] && [ -n "${!_STUB_DEBUG}" ] ; then

--- a/binstub
+++ b/binstub
@@ -74,12 +74,13 @@ while IFS= read -r line; do
     for (( i=0; i<${#parsed_patterns[@]}; i++ )); do
       pattern="${parsed_patterns[$i]}"
       argument="${arguments[$i]}"
-
-      if [[ "$pattern" != "$argument" ]] && [[ "$pattern" != "*" ]] ; then
-        debug "$(printf "match failed at idx %d, expected '%q', got '%q'" $i "$pattern" "$argument")"
-        match_found=2
-        break
-      fi
+      case "$argument" in
+        $pattern ) ;;
+        "$pattern" ) ;;
+        * ) debug "$(printf "match failed at idx %d, expected '%q', got '%q'" $i "$pattern" "$argument")"
+            match_found=2
+            break ;;
+      esac
     done
 
     # Check if there are unmatched arguments

--- a/binstub
+++ b/binstub
@@ -46,49 +46,55 @@ while IFS= read -r line; do
     # Start off by assuming success.
     match_found=1
 
-    # Split the line into an array of arguments to
-    # match and a command to run to produce output.
-    command=" $line"
-    if [ "$command" != "${command/ : }" ]; then
-      patterns="${command%% : *}"
-      command="${command#* : }"
-    fi
-
     arguments=("$@")
-    parsed_patterns=()
-
-    # Parse patterns into tokens using eval to respect quoted
-    # strings. This is less than ideal, but the pattern input
-    # is also already eval'd elsewhere. At least this handles
-    # things like newlines (which xargs doesn't)
-    origFlags="$-"
-    set -f
-    eval "parsed_patterns=(${patterns})"
-    set "-$origFlags"
-
-    debug "patterns  [${#parsed_patterns[@]}] = $(printf "'%q' " "${parsed_patterns[@]}")"
     debug "arguments [${#arguments[@]}] = $(printf "'%q' " "${arguments[@]}")"
 
-    # Match the expected argument patterns to actual
-    # arguments.
-    for (( i=0; i<${#parsed_patterns[@]}; i++ )); do
-      pattern="${parsed_patterns[$i]}"
-      argument="${arguments[$i]}"
-      case "$argument" in
-        $pattern ) ;;
-        "$pattern" ) ;;
-        * ) debug "$(printf "match failed at idx %d, expected '%q', got '%q'" $i "$pattern" "$argument")"
-            match_found=2
-            break ;;
-      esac
-    done
+    # Split the line into an array of arguments to match and a command to run.
+    # If the line does not contain ' : ' and does not start with a colon
+    # then the call is assumed to match any arguments and execute the command.
+    # Special case: Lines starting with double colon are also handled that way
+    # and get the double colons removed
+    command=" $line"
+    if [[ "$line" == ::* ]]; then
+      command="${line#::}"
+    elif [ "$command" != "${command/ : }" ]; then
+      patterns="${command%% : *}"
+      command="${command#* : }"
 
-    # Check if there are unmatched arguments
-    if [[ ${#arguments[@]} -gt ${#parsed_patterns[@]} ]] ; then
-      idx="${#parsed_patterns[@]}"
-      argument="${arguments[$idx]}"
-      debug "$(printf "unexpected argument '%q' at idx %d" "$argument" "$idx")"
-      match_found=3
+      parsed_patterns=()
+
+      # Parse patterns into tokens using eval to respect quoted
+      # strings. This is less than ideal, but the pattern input
+      # is also already eval'd elsewhere. At least this handles
+      # things like newlines (which xargs doesn't)
+      origFlags="$-"
+      set -f
+      eval "parsed_patterns=(${patterns})"
+      set "-$origFlags"
+
+      debug "patterns  [${#parsed_patterns[@]}] = $(printf "'%q' " "${parsed_patterns[@]}")"
+
+      # Match the expected argument patterns to actual
+      # arguments.
+      for (( i=0; i<${#parsed_patterns[@]}; i++ )); do
+        pattern="${parsed_patterns[$i]}"
+        argument="${arguments[$i]}"
+        case "$argument" in
+          $pattern ) ;;
+          "$pattern" ) ;;
+          * ) debug "$(printf "match failed at idx %d, expected '%q', got '%q'" $i "$pattern" "$argument")"
+              match_found=2
+              break ;;
+        esac
+      done
+
+      # Check if there are unmatched arguments
+      if [[ ${#arguments[@]} -gt ${#parsed_patterns[@]} ]] ; then
+        idx="${#parsed_patterns[@]}"
+        argument="${arguments[$idx]}"
+        debug "$(printf "unexpected argument '%q' at idx %d" "$argument" "$idx")"
+        match_found=3
+      fi
     fi
     break
   fi

--- a/binstub
+++ b/binstub
@@ -104,7 +104,7 @@ if [ -n "${!_STUB_END}" ]; then
   fi
 
   # Clean up the run file.
-  rm -f "${!_STUB_RUN}"
+  "$BATS_MOCK_REAL_rm" -f "${!_STUB_RUN}"
 
   # If the number of lines in the plan is larger than
   # the requested index, we failed.

--- a/binstub
+++ b/binstub
@@ -27,8 +27,8 @@ eval "${_STUB_INDEX}"=1
 eval "${_STUB_RESULT}"=0
 [ ! -e "${!_STUB_RUN}" ] || source "${!_STUB_RUN}"
 
-if [ -z "${!_STUB_END}" ] && [ -n "${!_STUB_DEBUG}" ]; then
-  debug "got $program $*" >&${!_STUB_DEBUG}
+if [ -z "${!_STUB_END}" ]; then
+  debug "got $program $*"
 fi
 
 # Loop over each line in the plan.

--- a/binstub
+++ b/binstub
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# If stdin comes from a pipe, save its content for later
-if ! [ -t 0 ]; then
-	input="$(cat)"
-fi
-
 # Assume failure of stubbed command
 status=1
 program="${0##*/}"
@@ -38,6 +33,7 @@ fi
 
 # Loop over each line in the plan.
 index=0
+match_found=0
 while IFS= read -r line; do
   index=$((index + 1))
 
@@ -48,7 +44,7 @@ while IFS= read -r line; do
   if [ -z "${!_STUB_END}" ] && [ $index -eq "${!_STUB_INDEX}" ]; then
     # We found the plan line we're interested in.
     # Start off by assuming success.
-    result=0
+    match_found=1
 
     # Split the line into an array of arguments to
     # match and a command to run to produce output.
@@ -78,7 +74,7 @@ while IFS= read -r line; do
 
       if [[ "$pattern" != "$argument" ]] && [[ "$pattern" != "*" ]] ; then
         debug "$(printf "match failed at idx %d, expected '%q', got '%q'" $i "$pattern" "$argument")"
-        result=1
+        match_found=2
         break
       fi
     done
@@ -88,23 +84,9 @@ while IFS= read -r line; do
       idx="${#parsed_patterns[@]}"
       argument="${arguments[$idx]}"
       debug "$(printf "unexpected argument '%q' at idx %d" "$argument" "$idx")"
-      result=2
-      break
+      match_found=3
     fi
-
-    # If the arguments matched, evaluate the command
-    # in a subshell. Otherwise, log the failure.
-    if [ $result -eq 0 ] ; then
-      debug "running $command"
-      debug "command input is $input"
-      set +e
-      ( eval "$command"  <<< "$input" )
-      status="$?"
-      debug "command result was $status"
-      set -e
-    else
-      eval "${_STUB_RESULT}"=1
-    fi
+    break
   fi
 done < "${!_STUB_PLAN}"
 
@@ -129,9 +111,16 @@ if [ -n "${!_STUB_END}" ]; then
   # Return the result.
   exit "${!_STUB_RESULT}"
 else
-  # If the requested index is larger than the number
-  # of lines in the plan file, we failed.
-  if [ "${!_STUB_INDEX}" -gt $index ]; then
+  # If the arguments matched, evaluate the command
+  # in a subshell. Otherwise, log the failure.
+  if [ $match_found -eq 1 ] ; then
+    debug "running $command"
+    set +e
+    ( eval "$command" )
+    status="$?"
+    debug "command result was $status"
+    set -e
+  else
     debug "no plan row found"
     eval "${_STUB_RESULT}"=1
   fi

--- a/binstub
+++ b/binstub
@@ -6,7 +6,8 @@ if ! [ -t 0 ]; then
 	input="$(cat)"
 fi
 
-status=0
+# Assume failure of stubbed command
+status=1
 program="${0##*/}"
 PROGRAM="$(echo "$program" | tr a-z- A-Z_)"
 
@@ -141,5 +142,5 @@ else
   } > "${!_STUB_RUN}"
 
   debug "result ${!_STUB_RESULT}"
-  exit "${!_STUB_RESULT}"
+  exit "$status"
 fi

--- a/binstub
+++ b/binstub
@@ -80,8 +80,15 @@ while IFS= read -r line; do
       for (( i=0; i<${#parsed_patterns[@]}; i++ )); do
         pattern="${parsed_patterns[$i]}"
         argument="${arguments[$i]}"
+
+        if [ "$pattern" = '*' ]; then
+          continue
+        fi
+
         case "$argument" in
-          $pattern ) ;;
+          # uncomment this line for partial pattern matching
+          # will break existing * matching and generate a shellcheck warning
+          # $pattern ) ;;
           "$pattern" ) ;;
           * ) debug "$(printf "match failed at idx %d, expected '%q', got '%q'" $i "$pattern" "$argument")"
               match_found=2

--- a/binstub
+++ b/binstub
@@ -15,7 +15,7 @@ _STUB_DEBUG="${PROGRAM}_STUB_DEBUG"
 
 debug() {
   if [ -n "${!_STUB_DEBUG}" ] ; then
-    echo "bats-mock($program): $*" >&${!_STUB_DEBUG}
+    echo "bats-mock($program): $*" >&"${!_STUB_DEBUG}"
   fi
 }
 
@@ -25,6 +25,7 @@ debug() {
 # Initialize or load the stub run information.
 eval "${_STUB_INDEX}"=1
 eval "${_STUB_RESULT}"=0
+# shellcheck source=stub.bash
 [ ! -e "${!_STUB_RUN}" ] || source "${!_STUB_RUN}"
 
 if [ -z "${!_STUB_END}" ]; then

--- a/binstub
+++ b/binstub
@@ -4,7 +4,14 @@ set -e
 # Assume failure of stubbed command
 status=1
 program="${0##*/}"
-PROGRAM="$(echo "$program" | tr a-z- A-Z_)"
+# shellcheck disable=SC2018,SC2019  # anything not A-Z0-9 will be _
+# the "\n" is necessary to avoid adding a trailing _ to the name
+PROGRAM="$(echo "${program}" | tr a-z A-Z | tr -C "A-Z0-9\n" '_')"
+
+if [[ "$PROGRAM" =~ ^[^A-Z_]+(.*)$ ]]; then
+  # remove leading non A-Z_ characters to make a valid variable name
+  PROGRAM="${BASH_REMATCH[1]}"
+fi
 
 _STUB_PLAN="${PROGRAM}_STUB_PLAN"
 _STUB_RUN="${PROGRAM}_STUB_RUN"

--- a/binstub
+++ b/binstub
@@ -38,9 +38,7 @@ match_found=0
 while IFS= read -r line; do
   index=$((index + 1))
 
-  # if [ -n "${!_STUB_DEBUG}" ]; then
-  #   echo "bats-mock: [idx $index, want ${!_STUB_INDEX}] $line" >&${!_STUB_DEBUG}
-  # fi
+  # debug "bats-mock: [idx $index, want ${!_STUB_INDEX}] $line"
 
   if [ -z "${!_STUB_END}" ] && [ $index -eq "${!_STUB_INDEX}" ]; then
     # We found the plan line we're interested in.

--- a/stub.bash
+++ b/stub.bash
@@ -15,7 +15,6 @@ stub() {
   mkdir -p "${BATS_MOCK_BINDIR}"
   ln -sf "${BASH_SOURCE[0]%stub.bash}binstub" "${BATS_MOCK_BINDIR}/${program}"
 
-  rm -f "${BATS_MOCK_TMPDIR}/${program}-stub-plan" "${BATS_MOCK_TMPDIR}/${program}-stub-run"
   touch "${BATS_MOCK_TMPDIR}/${program}-stub-plan"
   for arg in "$@"; do printf "%s\n" "$arg" >> "${BATS_MOCK_TMPDIR}/${program}-stub-plan"; done
 }

--- a/stub.bash
+++ b/stub.bash
@@ -1,6 +1,11 @@
 BATS_MOCK_TMPDIR="${BATS_TMPDIR}"
 BATS_MOCK_BINDIR="${BATS_MOCK_TMPDIR}/bin"
 
+export BATS_MOCK_REAL_mkdir=$(which mkdir)
+export BATS_MOCK_REAL_ln=$(which ln)
+export BATS_MOCK_REAL_touch=$(which touch)
+export BATS_MOCK_REAL_rm=$(which rm)
+
 PATH="$BATS_MOCK_BINDIR:$PATH"
 
 stub() {
@@ -12,10 +17,10 @@ stub() {
   export "${prefix}_STUB_RUN"="${BATS_MOCK_TMPDIR}/${program}-stub-run"
   export "${prefix}_STUB_END"=
 
-  mkdir -p "${BATS_MOCK_BINDIR}"
-  ln -sf "${BASH_SOURCE[0]%stub.bash}binstub" "${BATS_MOCK_BINDIR}/${program}"
+  "$BATS_MOCK_REAL_mkdir" -p "${BATS_MOCK_BINDIR}"
+  "$BATS_MOCK_REAL_ln" -sf "${BASH_SOURCE[0]%stub.bash}binstub" "${BATS_MOCK_BINDIR}/${program}"
 
-  touch "${BATS_MOCK_TMPDIR}/${program}-stub-plan"
+  "$BATS_MOCK_REAL_touch" "${BATS_MOCK_TMPDIR}/${program}-stub-plan"
   for arg in "$@"; do printf "%s\n" "$arg" >> "${BATS_MOCK_TMPDIR}/${program}-stub-plan"; done
 }
 
@@ -39,7 +44,7 @@ unstub() {
     STATUS=1
   fi
 
-  rm -f "$path"
-  rm -f "${BATS_MOCK_TMPDIR}/${program}-stub-plan" "${BATS_MOCK_TMPDIR}/${program}-stub-run"
+  "$BATS_MOCK_REAL_rm" -f "$path"
+  "$BATS_MOCK_REAL_rm" -f "${BATS_MOCK_TMPDIR}/${program}-stub-plan" "${BATS_MOCK_TMPDIR}/${program}-stub-run"
   return "$STATUS"
 }

--- a/stub.bash
+++ b/stub.bash
@@ -1,16 +1,21 @@
 BATS_MOCK_TMPDIR="${BATS_TMPDIR}"
 BATS_MOCK_BINDIR="${BATS_MOCK_TMPDIR}/bin"
 
-export BATS_MOCK_REAL_mkdir=$(which mkdir)
-export BATS_MOCK_REAL_ln=$(which ln)
-export BATS_MOCK_REAL_touch=$(which touch)
-export BATS_MOCK_REAL_rm=$(which rm)
+BATS_MOCK_REAL_mkdir=$(which mkdir)
+export BATS_MOCK_REAL_mkdir
+BATS_MOCK_REAL_ln=$(which ln)
+export BATS_MOCK_REAL_ln
+BATS_MOCK_REAL_touch=$(which touch)
+export BATS_MOCK_REAL_touch
+BATS_MOCK_REAL_rm=$(which rm)
+export BATS_MOCK_REAL_rm
 
 PATH="$BATS_MOCK_BINDIR:$PATH"
 
 stub() {
   local program="$1"
-  local prefix="$(echo "$program" | tr a-z- A-Z_)"
+  local prefix
+  prefix="$(echo "$program" | tr a-z- A-Z_)"
   shift
 
   export "${prefix}_STUB_PLAN"="${BATS_MOCK_TMPDIR}/${program}-stub-plan"
@@ -31,8 +36,9 @@ unstub() {
     shift
   fi
   local program="$1"
-  local prefix="$(echo "$program" | tr a-z- A-Z_)"
   local path="${BATS_MOCK_BINDIR}/${program}"
+  local prefix
+  prefix="$(echo "$program" | tr a-z- A-Z_)"
 
   export "${prefix}_STUB_END"=1
 

--- a/stub.bash
+++ b/stub.bash
@@ -15,8 +15,16 @@ PATH="$BATS_MOCK_BINDIR:$PATH"
 stub() {
   local program="$1"
   local prefix
-  prefix="$(echo "$program" | tr a-z- A-Z_)"
+  # shellcheck disable=SC2018,SC2019  # anything not A-Z0-9 will be _
+  # the "\n" is necessary to avoid adding a trailing _ to the name
+  prefix="$(echo "$program" | tr a-z A-Z | tr -C "A-Z0-9\n" '_')"
   shift
+
+
+  if [[ "$prefix" =~ ^[^A-Z_]+(.*)$ ]]; then
+    # remove leading non A-Z_ characters to make a valid variable name
+    prefix="${BASH_REMATCH[1]}"
+  fi
 
   export "${prefix}_STUB_PLAN"="${BATS_MOCK_TMPDIR}/${program}-stub-plan"
   export "${prefix}_STUB_RUN"="${BATS_MOCK_TMPDIR}/${program}-stub-run"
@@ -38,7 +46,14 @@ unstub() {
   local program="$1"
   local path="${BATS_MOCK_BINDIR}/${program}"
   local prefix
-  prefix="$(echo "$program" | tr a-z- A-Z_)"
+  # shellcheck disable=SC2018,SC2019  # anything not A-Z0-9 will be _
+  # the "\n" is necessary to avoid adding a trailing _ to the name
+  prefix="$(echo "${program}" | tr a-z A-Z | tr -C "A-Z0-9\n" '_')"
+
+  if [[ "$prefix" =~ ^[^A-Z_]+(.*)$ ]]; then
+    # remove leading non A-Z_ characters to make a valid variable name
+    prefix="${BASH_REMATCH[1]}"
+  fi
 
   export "${prefix}_STUB_END"=1
 

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -221,3 +221,15 @@ function teardown() {
   run unstub mycommand
   [ "$status" -eq 1 ]
 }
+
+@test "Allow incremental stubbing" {
+  stub mycommand "foo : echo OK"
+  stub mycommand "bar : echo 1K"
+  stub mycommand "baz : echo 2K"
+  run bash -c 'mycommand foo && mycommand bar && mycommand baz'
+  [ "$status" -eq 0 ]
+  expected='OK
+1K
+2K'
+  [ "$output" = "$expected" ]
+}

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -2,6 +2,11 @@
 
 load '../stub'
 
+function teardown() {
+    # Just clean up
+    unstub mycommand || true
+}
+
 # Uncomment to enable stub debug output:
 # export MYCOMMAND_STUB_DEBUG=/dev/tty
 
@@ -48,4 +53,35 @@ load '../stub'
   [[ "$output" == *"running llamas"* ]]
 
   unstub mycommand
+}
+
+@test "Return status of passed stub" {
+  stub myCommand \
+    " : return 1" \
+    " : return 42" \
+    " : return 0"
+  run myCommand
+  [ "$status" -eq 1 ]
+  [ "$output" == "" ]
+  run myCommand
+  [ "$status" -eq 42 ]
+  [ "$output" == "" ]
+  run myCommand
+  [ "$status" -eq 0 ]
+  [ "$output" == "" ]
+  unstub myCommand
+}
+
+@test "Succeed for empty stubbed command" {
+  stub mycommand
+  # mycommand not called
+  unstub mycommand
+}
+
+@test "Fail if empty subbed command called" {
+  stub mycommand
+  mycommand --help || true # Don't fail here
+  run unstub mycommand
+  [ "$status" -eq 1 ]
+  [[ "$output" == "" ]]
 }

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -7,11 +7,6 @@ function teardown() {
     unstub mycommand || true
 }
 
-function teardown() {
-    # Just clean up
-    unstub mycommand || true
-}
-
 # Uncomment to enable stub debug output:
 # export MYCOMMAND_STUB_DEBUG=/dev/tty
 
@@ -41,7 +36,7 @@ function teardown() {
 }
 
 
-@test "Invoke a stub multiple times" {
+@test "Invoke a stub to often" {
   stub mycommand "llamas : echo running llamas"
 
   run bash -c "mycommand llamas"
@@ -92,10 +87,23 @@ function teardown() {
   unstub mycommand
 }
 
-@test "Fail if empty subbed command called" {
+@test "Fail if empty stubbed command called" {
   stub mycommand
   mycommand --help || true # Don't fail here
   run unstub mycommand
   [ "$status" -eq 1 ]
-  [[ "$output" == "" ]]
+  [ "$output" == "" ]
+}
+
+@test "Fail if called out of sequence" {
+  stub mycommand \
+    "foo : echo 'OK'" \
+    "bar : echo '1K'" \
+    "baz : echo '2K'"
+  run bash -c "mycommand foo; mycommand baz; mycommand bar"
+  [ "$status" -eq 1 ]
+  [ "$output" == "OK" ]
+  run unstub mycommand
+  [ "$status" -eq 1 ]
+  [ "$output" == "" ]
 }

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -249,3 +249,44 @@ function teardown() {
   unstub touch
   unstub mycommand
 }
+
+@test "Allow any argument by omitting the args and colon" {
+  # 0 args
+  stub mycommand "echo OK"
+  run mycommand
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  # 1 arg
+  stub mycommand "echo OK"
+  run mycommand foo
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  # 2 args
+  stub mycommand "echo OK"
+  run mycommand foo bar
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  unstub mycommand
+}
+
+@test "Allow any argument by starting with double colon" {
+  # This allows including the colon separator in the command
+  stub mycommand "::echo ' includes : colon with spaces'"
+  run mycommand foo bar
+  [ "$status" -eq 0 ]
+  [ "$output" == ' includes : colon with spaces' ]
+  unstub mycommand
+}
+
+@test "Assume no arguments when starting with a colon and space" {
+  stub mycommand ": echo OK"
+  run mycommand
+  [ "$status" -eq 0 ]
+  [ "$output" == 'OK' ]
+  stub mycommand ": echo OK"
+  run mycommand foo
+  [ "$status" -eq 1 ]
+  [ "$output" == '' ]
+  run unstub mycommand
+  [ "$status" -eq 1 ]
+}

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -206,3 +206,18 @@ function teardown() {
   [ "$output" == "OK" ]
   unstub mycommand
 }
+
+@test "Allow partial matches" {
+  stub mycommand '/foo/bar/* : echo OK'
+  run mycommand "/foo/bar/myfile"
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  unstub mycommand
+  # But reject others
+  stub mycommand '/foo/bar/* : echo OK'
+  run mycommand "/foo/baz/myfile"
+  [ "$status" -eq 1 ]
+  [ "$output" == "" ]
+  run unstub mycommand
+  [ "$status" -eq 1 ]
+}

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -107,3 +107,16 @@ function teardown() {
   [ "$status" -eq 1 ]
   [ "$output" == "" ]
 }
+
+@test "Check stdin" {
+  file="$(mktemp "${BATS_TMPDIR}/output.XXXXXXXX")"
+  stub curl \
+    "foo : cat > '${file}'; echo 'mock output'"
+  run bash -c "echo 'Some input' | curl foo"
+  [ "$status" -eq 0 ]
+  [ "$output" == "mock output" ]
+  input="$(cat "$file")"
+  [ "$input" == "Some input" ]
+  rm "$file"
+  unstub curl
+}

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -7,6 +7,11 @@ function teardown() {
     unstub mycommand || true
 }
 
+function teardown() {
+    # Just clean up
+    unstub mycommand || true
+}
+
 # Uncomment to enable stub debug output:
 # export MYCOMMAND_STUB_DEBUG=/dev/tty
 
@@ -39,9 +44,18 @@ function teardown() {
 @test "Invoke a stub multiple times" {
   stub mycommand "llamas : echo running llamas"
 
-  run bash -c "mycommand llamas && mycommand alpacas"
+  run bash -c "mycommand llamas"
+  [ "$status" -eq 0 ]
+  [ "$output" == "running llamas" ]
 
+  # To often -> return failure
+  run bash -c "mycommand llamas"
   [ "$status" -eq 1 ]
+  [ "$output" == "" ]
+
+  run unstub mycommand
+  [ "$status" -eq 1 ]
+  [[ "$output" == "" ]]
 }
 
 @test "Stub a single command with quoted strings" {
@@ -57,9 +71,9 @@ function teardown() {
 
 @test "Return status of passed stub" {
   stub myCommand \
-    " : return 1" \
-    " : return 42" \
-    " : return 0"
+    " : exit 1" \
+    " : exit 42" \
+    " : exit 0"
   run myCommand
   [ "$status" -eq 1 ]
   [ "$output" == "" ]

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -157,3 +157,52 @@ function teardown() {
   [ "$status" -eq 0 ]
   [ "$output" == "" ]
 }
+
+@test "Using * as parameter matches any parameter" {
+  # * matches any param
+  stub mycommand '* : echo OK'
+  run mycommand foo
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  # Also works in any position
+  stub mycommand 'first second * : echo OK'
+  run mycommand first second foo
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  stub mycommand 'first * last : echo OK'
+  run mycommand first foo last
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  stub mycommand '* second last : echo OK'
+  run mycommand foo second last
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  # Also matches literal *
+  stub mycommand '* : echo OK'
+  run mycommand '*'
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  unstub mycommand
+}
+
+@test "Match parameters with whitespace" {
+  # Single quotes
+  stub mycommand "'first arg' 'second arg' : echo OK"
+  run mycommand "first arg" "second arg"
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  # Double quotes
+  stub mycommand '"first arg" "second arg" : echo OK'
+  run mycommand "first arg" "second arg"
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  unstub mycommand
+}
+
+@test "Match parameter with embedded command line" {
+  stub mycommand "-c 'echo \"Hello \$USER\"' : echo OK"
+  run mycommand -c 'echo "Hello $USER"'
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  unstub mycommand
+}

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -233,3 +233,19 @@ function teardown() {
 2K'
   [ "$output" = "$expected" ]
 }
+
+@test "Stubbing still works when some util binaries are stubbed" {
+  stub rm
+  stub mkdir
+  stub ln
+  stub touch
+  stub mycommand " : echo OK"
+  run mycommand
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  unstub rm
+  unstub mkdir
+  unstub ln
+  unstub touch
+  unstub mycommand
+}

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -165,20 +165,20 @@ function teardown() {
   [ "$status" -eq 0 ]
   [ "$output" == "OK" ]
   # Also works in any position
-  stub mycommand 'first second * : echo OK'
+  stub mycommand 'first second \* : echo OK'
   run mycommand first second foo
   [ "$status" -eq 0 ]
   [ "$output" == "OK" ]
-  stub mycommand 'first * last : echo OK'
+  stub mycommand 'first \* last : echo OK'
   run mycommand first foo last
   [ "$status" -eq 0 ]
   [ "$output" == "OK" ]
-  stub mycommand '* second last : echo OK'
+  stub mycommand '\* second last : echo OK'
   run mycommand foo second last
   [ "$status" -eq 0 ]
   [ "$output" == "OK" ]
   # Also matches literal *
-  stub mycommand '* : echo OK'
+  stub mycommand '\* : echo OK'
   run mycommand '*'
   [ "$status" -eq 0 ]
   [ "$output" == "OK" ]
@@ -209,6 +209,7 @@ function teardown() {
 }
 
 @test "Allow partial matches" {
+  skip
   stub mycommand '/foo/bar/* : echo OK'
   run mycommand "/foo/bar/myfile"
   [ "$status" -eq 0 ]

--- a/tests/binstub.bats
+++ b/tests/binstub.bats
@@ -201,6 +201,7 @@ function teardown() {
 
 @test "Match parameter with embedded command line" {
   stub mycommand "-c 'echo \"Hello \$USER\"' : echo OK"
+  # shellcheck disable=SC2016  # this is on purpose
   run mycommand -c 'echo "Hello $USER"'
   [ "$status" -eq 0 ]
   [ "$output" == "OK" ]

--- a/tests/mock_functions.bats
+++ b/tests/mock_functions.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+load '../stub'
+
+function rm {
+    return 1
+}
+function mkdir {
+    return 1
+}
+function ln {
+    return 1
+}
+function touch {
+    return 1
+}
+
+@test "Stubbing still works when some util binaries are mock functions" {
+  stub mycommand " : echo OK"
+  run mycommand
+  [ "$status" -eq 0 ]
+  [ "$output" == "OK" ]
+  unstub mycommand
+}

--- a/tests/mock_functions.bats
+++ b/tests/mock_functions.bats
@@ -3,16 +3,16 @@
 load '../stub'
 
 function rm {
-    return 1
+  return 1
 }
 function mkdir {
-    return 1
+  return 1
 }
 function ln {
-    return 1
+  return 1
 }
 function touch {
-    return 1
+  return 1
 }
 
 @test "Stubbing still works when some util binaries are mock functions" {

--- a/tests/mock_functions.bats
+++ b/tests/mock_functions.bats
@@ -16,6 +16,9 @@ function touch {
 }
 
 @test "Stubbing still works when some util binaries are mock functions" {
+  run rm ../README.md
+  [ "$status" -eq 1 ]
+
   stub mycommand " : echo OK"
   run mycommand
   [ "$status" -eq 0 ]

--- a/tests/program_names.bats
+++ b/tests/program_names.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+load '../stub'
+
+# As the executable names are used to create variable names, we need to check
+# what happens when characters are valid in one but not the other
+
+@test "Stub a command with spaces in its name" {
+  stub 'my command' "echo run with \${@}"
+
+  run 'my command' llamas on fire
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == "run with llamas on fire" ]]
+
+  unstub 'my command'
+}
+
+@test "Stub a command a period in its name" {
+  stub CMD.EXE "echo run with \${@}"
+
+  run CMD.EXE llamas on fire
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == "run with llamas on fire" ]]
+
+  unstub CMD.EXE
+}
+
+@test "Stub a command with only non-latin characters" {
+  stub á€äßø "echo run with \${@}"
+
+  run á€äßø llamas on fire
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == "run with llamas on fire" ]]
+
+  unstub á€äßø
+}
+
+@test "Stub a command that does not start with a letter" {
+  stub 0-day "echo run with \${@}"
+
+  run 0-day llamas on fire
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == "run with llamas on fire" ]]
+
+  unstub 0-day
+}
+


### PR DESCRIPTION
This is *almost* the same as #7. I used it as a starting point merging it to master.

* New features
  - `unstub --allow-missing`:  https://github.com/buildkite-plugins/bats-mock/commit/74443ffda9b0b8c4dca95bd1e00b357e3806773b as an alternative to #6 
  - bring back incremental execution plans: https://github.com/buildkite-plugins/bats-mock/commit/4a36b56aae2ae1526b6a5bc11b393e80bb06a258
  - Allow any number of arguments: 0decdc2
* Bugs fixed:
  - handling of '*': https://github.com/buildkite-plugins/bats-mock/commit/5c093151dbd9181a856268f03568b5e129308f22

### Removed changes from #7

* Partial matching
  - NB: I believe that it may be an interesting feature, but it will probably break a lot of existing tests and it was the only breaking change. I did not remove the code, just [commented it out](https://github.com/buildkite-plugins/bats-mock/pull/11/commits/5db6c3efc246df2c0384bc73969e3ae87a2fb225)
* wrong exit status (had already been corrected)

### Added changes on top of #7 

* Corrected all shellcheck warnings
* Removed assumption of partial stubbing from some tests
* Corrected handling of commands that don't make for valid variable names and added tests for it as well (closes #9)

You can run all tests with `docker run --rm -ti -v $PWD:/code bats/bats tests`