### PR TITLE
Fix shellcheck

### DIFF
--- a/tests/mock_functions.bats
+++ b/tests/mock_functions.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# shellcheck disable=SC2317
+# shellcheck disable=SC2329
 # because we are declaring functions inside the setup function itself
 
 load '../stub'


### PR DESCRIPTION
Last runs of the pipeline failed [1](https://buildkite.com/buildkite/plugins-bats-mock/builds/10) [2](https://buildkite.com/buildkite/plugins-bats-mock/builds/12) because shellcheck now has a separate code for unreachable functions - previously the same as unrechable commands.